### PR TITLE
Fix: container issue by setting default as assets (closes #3)

### DIFF
--- a/resources/blueprints/config.yaml
+++ b/resources/blueprints/config.yaml
@@ -95,6 +95,7 @@ tabs:
                   field:
                     type: 'assets'
                     display: 'Attachment'
+                    container: assets
                     max_files: 1
                     width: 50
                     instructions: 'Optional file to attach to the auto-reply email.'


### PR DESCRIPTION
Added the container name as assets in the blueprint to resolve the shared array key error and ensure the container loads correctly.